### PR TITLE
Corrigindo bug base64.encodestring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build/
 dist/
 MANIFEST
 .*.sw*
+.idea/
+.env/

--- a/iugu/iuguapi.py
+++ b/iugu/iuguapi.py
@@ -3,11 +3,10 @@
 import os
 import re
 import json
-import base64
 import requests
 from iugu import exception
 from iugu.version import __version__
-
+from requests.auth import HTTPBasicAuth
 
 class IuguApi(object):
 
@@ -16,8 +15,6 @@ class IuguApi(object):
 
     def headers(self):
         return {
-            "Authorization": "Basic %s" % base64.encodestring(
-                "%s:" % self.token).replace("\n", ""),
             "User-Agent": "Iugu Python Api %s" % __version__,
             "Content-Type": "application/json",
             "Accept": "application/json"
@@ -26,6 +23,7 @@ class IuguApi(object):
     def base_request(self, url, method, data={}):
         try:
             response = requests.request(method, url,
+                                        auth=HTTPBasicAuth(self.token, ''),
                                         data=json.dumps(data),
                                         headers=self.headers())
             return json.loads(response.content.decode('utf-8'))

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-try:
-    from distutils.core import setup
-except ImportError:
-    from setuptools import setup
+from setuptools import setup
 
 import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'iugu'))

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-from setuptools import setup
+
+try:
+    from distutils.core import setup
+except ImportError:
+    from setuptools import setup
 
 import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'iugu'))


### PR DESCRIPTION
Na versão 3.4+ esse método está deprecated, não é possível usar ele com uma string como estava sendo usado.
Fiz algumas mudanças para usar "auth=HTTPBasicAuth(self.token, '')" ao invés de passar como header e ter que codificar para base64, pois a biblioteca requests já tem uma classe responsável por isso o HTTPBasicAuth.
Funciona tanto no python2.7 quanto 3+
Abs