### PR TITLE
Variável não declarada

### DIFF
--- a/iugu/marketplace.py
+++ b/iugu/marketplace.py
@@ -22,4 +22,4 @@ class MarketPlace(Action):
 
     def sub_account(self, id):
         url = self.api.make_url(['accounts', id])
-        return super(MarketPlace, self).list(url, data)
+        return super(MarketPlace, self).list(url)


### PR DESCRIPTION
A variável ```data``` era inexistente e desnecessária no método ```sub_account``` no ```marketplace```. Como o método ```list``` de ```Action``` tem valor padrão, não é necessário passar um valor para o método.