### PR TITLE
Removed slash ('/') at the end of URL for python 3.8 compatibility

### DIFF
--- a/iugu/iuguapi.py
+++ b/iugu/iuguapi.py
@@ -44,7 +44,7 @@ class IuguApi(object):
         return self.base_request(url, 'DELETE')
 
     def make_url(self, paths):
-        url = 'https://api.iugu.com/v1/'
+        url = 'https://api.iugu.com/v1'
         for path in paths:
             url = re.sub(r'/?$', re.sub(r'^/?', '/', str(path)), url)
         return url


### PR DESCRIPTION
When we're using Python 3.8 we get a duplicated path when URL ends with '/'.
i.e.: 'https://api.iugu.com/v1/customers/customers'